### PR TITLE
Script to disconnect the Remote Session without locking the machine

### DIFF
--- a/test/RDPSession/disconnect.bat
+++ b/test/RDPSession/disconnect.bat
@@ -1,4 +1,4 @@
-REM This batch script disconnects the Remote Desktop Session without locking the machine. 
+REM This batch script disconnects the Remote Desktop Session without locking the machine. Run with Administrator privileges.
 REM Useful in case of running Coded UI Tests where user want to end the remote desktop session but at the same time doesn't want to lock the machine
 
 for /F "usebackq tokens=1" %%f in (`query session ^| findstr /C:^^^>`) do set session="%%f"


### PR DESCRIPTION
Adding the script to disconnect the Remote Desktop Session without locking the machine. Useful in case of running Coded UI Tests where user want to end the remote desktop session but at the same time doesn't want to lock the machine
